### PR TITLE
[FIX] common-mvc 라이브러리 설정에 의해 spring.application.name 덮어쓰기 문제 해결

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -70,7 +70,7 @@ dependencies {
 
 
     // common
-    implementation 'com.athenhub:common-mvc:1.1.0'
+    implementation 'com.athenhub:common-mvc:1.1.1'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -3,12 +3,12 @@ spring:
     name: member-service
   config:
     import:
-     - 'optional:configserver:http://3.38.80.105:9100'
+      - 'optional:configserver:'
   cloud:
     config:
       discovery:
         enabled: false
-        #service-id: ${CLOUD_SERVICE_ID}
+        service-id: ${CLOUD_SERVICE_ID}
 
 eureka:
   instance:


### PR DESCRIPTION
## 🛠️ 작업 내용 (Details)
- member-service 실행 시 spring.application.name=member-service 값이 정상 적용되지 않고 Eureka Dashboard에 COMMON-MVC로 등록되는 문제 발생
- 원인은 build.gradle에서 추가한 common-mvc 라이브러리 내부의 application.yml설정이 우선순위로 적용되어 spring.application.name=common-mvc로 덮어씌였기 때문

- 해결 방법으로 build.gradle 에서 버전을 mvc:1.1.0 -> mvc:1.1.1로 번경

## 🔀 변경 유형 (Change Type)

어떤 종류의 변경사항인지 해당 항목에 [x]를 표기해주세요.
- [ ] 새로운 기능 추가 (non-breaking change which adds functionality)
- [ ] 코드 수정 (non-breaking change which fixes functionality)
- [x] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [ ] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)


## 🧪 테스트 방법 (Testing)