### PR TITLE
feat: member-service swagger 세팅

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,6 +24,8 @@ configurations {
 }
 
 repositories {
+    mavenLocal()  // ⬅ 여기 추가
+
     mavenCentral()
 
     maven {
@@ -70,7 +72,7 @@ dependencies {
 
 
     // common
-    implementation 'com.athenhub:common-mvc:1.1.0'
+    implementation 'com.athenhub:common-mvc:1.2.0'
 
     // lombok
     compileOnly 'org.projectlombok:lombok'
@@ -85,6 +87,10 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Swagger
+    implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.14'
+
 
     // mockito javaagent
     mockitoAgent('org.mockito:mockito-core') {

--- a/src/main/java/com/athenhub/memberservice/global/security/MemberSecurityConfig.java
+++ b/src/main/java/com/athenhub/memberservice/global/security/MemberSecurityConfig.java
@@ -1,0 +1,50 @@
+package com.athenhub.memberservice.global.security;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+/**
+ * member-service 애플리케이션의 Spring Security 설정을 담당하는 구성 클래스.
+ *
+ * <p>공통 모듈에서 제공하는 기본 보안 설정(BaseSecurityConfig)이 아닌, 이 서비스에 특화된 보안 규칙을 정의한다. <br>
+ * Actuator(헬스 체크) 및 Swagger UI / OpenAPI 문서 관련 엔드포인트는 인증 없이 접근할 수 있도록 허용하고, 그 외 모든 요청은 인증을 요구한다.
+ */
+@Configuration
+@EnableWebSecurity
+public class MemberSecurityConfig {
+
+  /**
+   * member-service에 적용될 {@link SecurityFilterChain}을 구성한다.
+   *
+   * <p>설정 내용은 다음과 같다.
+   *
+   * <ul>
+   *   <li>CSRF 비활성화: REST API + 토큰 기반 인증 환경을 가정하고 있으므로 사용하지 않는다.
+   *   <li>Actuator 및 Swagger 관련 엔드포인트는 모두 공개(permitAll).
+   *   <li>위에서 명시적으로 허용하지 않은 나머지 모든 요청은 인증을 필수로 요구한다.
+   * </ul>
+   *
+   * @param http Spring Security의 HTTP 보안 구성을 위한 {@link HttpSecurity}
+   * @return 설정이 적용된 {@link SecurityFilterChain} 인스턴스
+   * @throws Exception 보안 설정 빌드 과정에서 발생할 수 있는 예외
+   */
+  @Bean
+  public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+    http.csrf(csrf -> csrf.disable())
+        .authorizeHttpRequests(
+            auth ->
+                auth.requestMatchers(
+                        "/actuator/**",
+                        "/swagger-ui.html",
+                        "/swagger-ui/**",
+                        "/v3/api-docs/**",
+                        "/api-docs.html")
+                    .permitAll()
+                    .anyRequest()
+                    .authenticated());
+    return http.build();
+  }
+}

--- a/src/main/java/com/athenhub/memberservice/infrastructure/SwaggerConfig.java
+++ b/src/main/java/com/athenhub/memberservice/infrastructure/SwaggerConfig.java
@@ -1,0 +1,116 @@
+package com.athenhub.memberservice.infrastructure;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.PathItem;
+import io.swagger.v3.oas.models.Paths;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springdoc.core.customizers.OpenApiCustomizer;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Member 서비스의 Swagger / OpenAPI 설정을 담당하는 구성 클래스.
+ *
+ * <p>springdoc-openapi를 기반으로 다음과 같은 역할을 수행한다.
+ *
+ * <ul>
+ *   <li>기본 OpenAPI 메타 정보(title, description 등) 설정
+ *   <li>JWT Bearer 인증 스키마를 정의하고, 모든 API에 기본 보안 요구사항으로 추가
+ *   <li>Gateway를 통해 접근하는 실제 경로(/v1/members/**)가 문서에 반영되도록 경로를 변환
+ * </ul>
+ */
+@Configuration
+public class SwaggerConfig {
+
+  /** Gateway에서 Member 서비스로 라우팅될 때 사용되는 공통 경로(prefix). */
+  private static final String pathPrefix = "/v1/members";
+
+  /**
+   * 기본 OpenAPI 정보와 JWT 보안 설정을 구성한다.
+   *
+   * <p>다음과 같은 설정을 수행한다.
+   *
+   * <ul>
+   *   <li>문서 상의 Server URL을 외부에서 주입받은 base URL로 설정
+   *   <li>HTTP Bearer(JWT) 타입의 SecurityScheme를 등록
+   *   <li>등록된 Bearer 스키마를 전역 SecurityRequirement로 추가하여 기본 인증 요구사항으로 사용
+   *   <li>문서 제목 및 설명 등 기본 메타 정보 설정
+   * </ul>
+   *
+   * @param url 게이트웨이 또는 해당 서비스에 접근하기 위한 base URL (예: {@code
+   *     https://api.athenhub.xyz/member-service})
+   * @return 구성된 {@link OpenAPI} 스펙 객체
+   */
+  @Bean
+  public OpenAPI openApi(@Value("${openapi.service.url}") String url) {
+    return new OpenAPI()
+        .servers(List.of(new Server().url(url)))
+        .components(
+            new Components()
+                .addSecuritySchemes(
+                    "Bearer",
+                    new SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("bearer")
+                        .bearerFormat("JWT")))
+        .addSecurityItem(new SecurityRequirement().addList("Bearer"))
+        .info(new Info().title("Athen Hub").description("MEMBER API"));
+  }
+
+  /**
+   * Member 서비스의 실제 엔드포인트 경로 앞에 Gateway prefix({@code /v1/members})를 추가하여, 클라이언트 관점에서 보이는 최종 경로가
+   * OpenAPI 문서에 반영되도록 경로를 변환하는 커스터마이저를 등록한다.
+   *
+   * <p>동작 방식은 다음과 같다.
+   *
+   * <ul>
+   *   <li>현재 등록된 모든 path를 복사하여 {@code /v1/members} prefix가 붙은 경로로 다시 추가
+   *   <li>원본 경로(서비스 내부 경로)는 제거하고, Gateway를 통한 외부 공개 경로만 문서에 남긴다.
+   *   <li>이미 prefix가 붙은 경로는 중복 추가하지 않는다.
+   * </ul>
+   *
+   * <p>예시:
+   *
+   * <ul>
+   *   <li>실제 컨트롤러 경로: {@code /members}
+   *   <li>문서에 노출되는 경로: {@code /v1/members/members}
+   * </ul>
+   *
+   * @return OpenAPI의 paths를 변환하는 {@link OpenApiCustomizer} 구현체
+   */
+  @Bean
+  public OpenApiCustomizer addPrefixToPaths() {
+    return openApi -> {
+      Paths paths = openApi.getPaths();
+      if (paths == null) {
+        return;
+      }
+
+      // 기존 paths를 복사하여 prefix를 붙인 새로운 경로를 추가
+      Map<String, PathItem> original = new LinkedHashMap<>(paths);
+      for (String path : original.keySet().toArray(new String[0])) {
+        String prefixed = pathPrefix + path;
+        if (!paths.containsKey(prefixed)) {
+          PathItem item = original.get(path);
+          paths.addPathItem(prefixed, item);
+        }
+      }
+
+      // prefix가 없는 실제 내부 경로는 제거하고,
+      // Gateway를 통해 접근하는 외부 공개 경로만 문서에 남긴다.
+      for (String path : original.keySet()) {
+        if (!path.startsWith(pathPrefix)) {
+          paths.remove(path);
+        }
+      }
+    };
+  }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -20,3 +20,23 @@ eureka:
     fetch-registry: true
     service-url:
       defaultZone: ${EUREKA_SERVICE_URL}
+
+# OPEN DOC API 설정
+springdoc:
+  version: '1.0.0'
+  api-docs:
+    path: /v3/api-docs
+  default-consumes-media-type: application/json
+  default-produces-media-type: application/json
+  swagger-ui:
+    operations-sorter: alpha
+    tags-sorter: alpha
+    path: /api-docs.html
+    disable-swagger-default-url: true
+    doc-expansion: full
+  paths-to-match:
+    - /**
+
+openapi:
+  service:
+    url: http://localhost:9000

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,36 @@
+spring:
+  application:
+    name: member-service-test
+
+  # ✅ 테스트에서는 config-server 안 타게 덮어쓰기
+  config:
+    import: ''   # main application.yml의 configserver import 제거
+
+  cloud:
+    config:
+      enabled: false          # Config Client 비활성화
+      import-check:
+        enabled: false        # import 누락 검사도 비활성화
+
+  # ✅ 테스트용 H2 메모리 DB 설정
+  datasource:
+    url: jdbc:h2:mem:memberdb;MODE=PostgreSQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.PostgreSQLDialect
+
+  sql:
+    init:
+      mode: never
+
+# ✅ SwaggerConfig에서 사용하는 값 (테스트 기준 base URL)
+openapi:
+  service:
+    url: http://localhost:9000


### PR DESCRIPTION
see also: #3

## 🛠️ 작업 내용 (Details)
- member-servie에 Swagger 연동
- SwaggerConfig 추가
- MemberSecurityConfig 추가

## 🔀 변경 유형 (Change Type)

어떤 종류의 변경사항인지 해당 항목에 [x]를 표기해주세요.
- [x] 새로운 기능 추가 (non-breaking change which adds functionality)
- [ ] 코드 수정 (non-breaking change which fixes functionality)
- [ ] 버그 수정 (non-breaking change which fixes an issue)
- [ ] 코드 스타일 업데이트 (formatting, renaming)
- [ ] 코드 리팩토링 (non-breaking change which improves code)
- [ ] 문서 수정 (documentation only)
- [ ] 기타 (설명: )
- [ ] 성능 개선 (performance improvement)
- [ ] 파괴적인 변경 (breaking change which might cause existing functionality to break)


## 🧪 테스트 방법 (Testing)
- 로컬 환경에서 `member-service` 기동
- 브라우저에서 다음 경로 접속 후 정상 응답 여부 확인
  - `http://localhost:9012/actuator/health` → `UP` 응답 확인
  - `http://localhost:9012/v3/api-docs` → OpenAPI JSON 응답 확인
  - `http://localhost:9012/swagger-ui.html` (또는 `/swagger-ui/index.html`) → Swagger UI 로딩 확인
- Swagger UI에서 샘플 API 호출 시
  - 공개 엔드포인트(헬스, 문서)는 인증 없이 요청 가능함을 확인
  - 인증이 필요한 엔드포인트는 적절히 401/403 응답이 동작하는지 확인